### PR TITLE
Checkout section Missing

### DIFF
--- a/shop/application/mayocat.yml.example
+++ b/shop/application/mayocat.yml.example
@@ -91,3 +91,6 @@ catalog:
       default: true
       configurable: false
       visible: false
+
+checkout:
+  defaultPaymentGateway: paypaladaptivepayments


### PR DESCRIPTION
Added checkout section in Mayocat.yml.example for the defaultPaymentGateway parameter
