### PR TITLE
Remove the clear of the localStorage since Less perfectly handles this

### DIFF
--- a/shop/client/src/main/resources/assets/client/index.htm
+++ b/shop/client/src/main/resources/assets/client/index.htm
@@ -49,8 +49,6 @@
     <script src="/common/vendor/ckeditor/4.1/ckeditor.js"></script>
 
     <script src="/common/vendor/lesscss/less-1.3.3.min.js"></script>
-    <!-- Always clear local storage when running with less.js -->
-    <script>localStorage.clear();</script>
 
     <!-- Application scripts -->
     <script src="/common/javascripts/polyfill.js"></script>


### PR DESCRIPTION
The cache problem is due to a bug with Chrome, clearing the `localStorage` doesn't solve anything.
