### PR TITLE
Add missing code to allow metadata updates to work

### DIFF
--- a/shop/client/src/main/resources/assets/client/partials/article.html
+++ b/shop/client/src/main/resources/assets/client/partials/article.html
@@ -39,12 +39,32 @@
                                             href="#editThumbnails">
                                             {{'entity.action.editThumbnails' | translate}}
                                         </li>
+                                        <li ng-click="image.editMeta = true">
+                                            {{'image.action.editMetadata' | translate}}
+                                        </li>
                                         <li ng-click="removeImage(image)">
                                             {{'entity.action.remove' | translate}}
                                         </li>
                                     </ul>
                                 </div>
                                 <div class="clearfix"></div>
+                            </div>
+                            <div ng-show="image.editMeta" class="metadata">
+                                <div>
+                                    <input type="text" ng-model="image.title"
+                                           placeholder="{{'upload.placeholder.title' | translate}}"/>
+                                </div>
+                                <div>
+                                    <textarea rows="5" ng-model="image.description"
+                                              placeholder="{{'upload.placeholder.description' | translate}}"></textarea>
+                                </div>
+                                <span ng-class="{'loading': image.isSaving}"></span>
+                                <button type="button" class="btn" ng-click="image.editMeta = false">
+                                    {{'entity.action.cancel' | translate}}
+                                </button>
+                                <button type="button" class="btn btn-primary" ng-click="updateImageMeta(image)">
+                                    {{'entity.action.update' | translate}}
+                                </button>
                             </div>
                         </div>
                     </li>

--- a/shop/client/src/main/resources/assets/client/partials/page.html
+++ b/shop/client/src/main/resources/assets/client/partials/page.html
@@ -39,12 +39,32 @@
                                             href="#editThumbnails">
                                             {{'entity.action.editThumbnails' | translate}}
                                         </li>
+                                        <li ng-click="image.editMeta = true">
+                                            {{'image.action.editMetadata' | translate}}
+                                        </li>
                                         <li ng-click="removeImage(image)">
                                             {{'entity.action.remove' | translate}}
                                         </li>
                                     </ul>
                                 </div>
                                 <div class="clearfix"></div>
+                            </div>
+                            <div ng-show="image.editMeta" class="metadata">
+                                <div>
+                                    <input type="text" ng-model="image.title"
+                                           placeholder="{{'upload.placeholder.title' | translate}}"/>
+                                </div>
+                                <div>
+                                    <textarea rows="5" ng-model="image.description"
+                                              placeholder="{{'upload.placeholder.description' | translate}}"></textarea>
+                                </div>
+                                <span ng-class="{'loading': image.isSaving}"></span>
+                                <button type="button" class="btn" ng-click="image.editMeta = false">
+                                    {{'entity.action.cancel' | translate}}
+                                </button>
+                                <button type="button" class="btn btn-primary" ng-click="updateImageMeta(image)">
+                                    {{'entity.action.update' | translate}}
+                                </button>
                             </div>
                         </div>
                     </li>

--- a/shop/client/src/main/resources/assets/client/partials/product.html
+++ b/shop/client/src/main/resources/assets/client/partials/product.html
@@ -58,6 +58,7 @@
                                     <textarea rows="5" ng-model="image.description"
                                               placeholder="{{'upload.placeholder.description' | translate}}"></textarea>
                                 </div>
+                                <span ng-class="{'loading': image.isSaving}"></span>
                                 <button type="button" class="btn" ng-click="image.editMeta = false">
                                     {{'entity.action.cancel' | translate}}
                                 </button>

--- a/shop/client/src/main/resources/assets/client/stylesheets/app.less
+++ b/shop/client/src/main/resources/assets/client/stylesheets/app.less
@@ -71,6 +71,11 @@
   height: 210px;
   border-bottom-right-radius: 5px;
   border-top-right-radius: 5px;
+  text-align: left;
+
+  .loading {
+    float: right;
+  }
 }
 
 .entity ul.thumbnails .thumbnail .caption .dropdown-menu li {

--- a/shop/client/src/main/resources/assets/common/javascripts/entities.js
+++ b/shop/client/src/main/resources/assets/common/javascripts/entities.js
@@ -177,13 +177,32 @@
                     $rootScope.$broadcast('thumbnails:edit', entityType, image);
                 }
 
+                mixin.updateImageMeta = function (image) {
+                    image.isSaving = true;
+
+                    var scope = this;
+                    $http.post("/api/" + entityType + "s/" + scope.slug + "/images/" + image.slug, image)
+                        .success(function(data, status) {
+                            image.isSaving = false;
+
+                            if(status < 400) {
+                                image.editMeta = false;
+                            } else {
+                                $rootScope.$broadcast('event:serverError');
+                            }
+                        })
+                        .error(function() {
+                            image.isSaving = false;
+                            $rootScope.$broadcast('event:serverError');
+                        });
+                }
+
                 mixin.reloadImages = function () {
                     var scope = this;
                     $http.get("/api/" + entityType + "s/" + scope.slug + "/images")
                         .success(function (data) {
                             scope[entityType].images = data;
-                        }
-                    );
+                        });
                 }
 
                 mixin.selectFeatureImage = function (image) {


### PR DESCRIPTION
This PR allows a user to update the metadata of an image.

**Note:** This will fully work once the entity mixins will be added to the article news. Also, the server API must handle the requests for the page and article entities.
