### PR TITLE
Fix some JS errors about missing modules in the manager

### DIFF
--- a/shop/client/src/main/resources/assets/manager/index.htm
+++ b/shop/client/src/main/resources/assets/manager/index.htm
@@ -65,6 +65,8 @@
     <script src="/common/javascripts/configuration.js"></script>
     <script src="/common/javascripts/mixins.js"></script>
     <script src="/common/javascripts/entities.js"></script>
+    <script src="/common/javascripts/upload.js"></script>
+    <script src="/common/javascripts/notifications.js"></script>
 
     <script src="javascripts/app.js"></script>
 


### PR DESCRIPTION
This was litteraly blocking any access to the manager
